### PR TITLE
fix: align order model name with schema

### DIFF
--- a/backend/models/orderModel.js
+++ b/backend/models/orderModel.js
@@ -10,6 +10,6 @@ const orderSchema = new mongoose.Schema({
     payment: { type: Boolean, default: false }
 })
 
-const orderModel = mongoose.models.order || mongoose.model("pedido",orderSchema);
+const orderModel = mongoose.models.order || mongoose.model("order", orderSchema);
 
 export default orderModel;


### PR DESCRIPTION
## Summary
- ensure order model uses consistent name with its schema

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6895f15032848328b58cf63cc7cd6b69